### PR TITLE
更改ffmpeg参数

### DIFF
--- a/xiaoet.py
+++ b/xiaoet.py
@@ -216,7 +216,7 @@ class Xet(object):
             with open(os.path.join(resource_dir, 'metadata')) as f:
                 metadata = json.load(f)
             if metadata['complete']:
-                ff = ffmpy.FFmpeg(inputs={os.path.join(resource_dir, 'video.m3u8'): ['-protocol_whitelist', 'crypto,file,http,https,tcp,tls']}, outputs={os.path.join(self.download_dir, metadata['title'] + '.mp4'): None})
+                ff = ffmpy.FFmpeg(inputs={os.path.join(resource_dir, 'video.m3u8'): ['-protocol_whitelist', 'crypto,file,http,https,tcp,tls']}, outputs={os.path.join(self.download_dir, metadata['title'] + '.mp4'): "-c:v copy -c:a copy"})
                 print(ff.cmd)
                 ff.run()
         return


### PR DESCRIPTION
参数留空会导致ff使用默认参数进行压制，时间上难以接受；将其更改为copy即可仅合并视频且不损失视频清晰度